### PR TITLE
adds issuer with known did seed for testing purposes

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -1,13 +1,18 @@
 {
   "meta": {
      "created": "2020-12-02T02:32:16+0000",
-     "updated": "2021-09-20T01:06:23+0000"
+     "updated": "2021-12-05T23:55:00+0000"
   },
   "registry": {
      "did:key:z6Mktpn6cXks1PBKLMgZH2VaahvCtBMF6K8eCa7HzrnuYLZv": {
         "name": "Example University 1 (DCC test-only issuer)",
         "location": "Cambridge, MA, USA",
         "url": "https://openlearning.mit.edu"
+     },
+     "did:key:z6MkhVTX9BF3NGYX6cc7jWpbNnR7cAjH8LUffabZP8Qu4ysC": {
+        "name": "DCC Playground",
+        "location": "Cambridge, MA, USA",
+        "url": "https://digitalcredentials.github.io/playground"
      },
      "did:web:digitalcredentials.odl.mit.edu": {
         "name": "MIT xPRO",


### PR DESCRIPTION
This PR adds an issuer with a `did:key` ID associated with a known seed for testing purposes