### PR TITLE
Add TLN Unconference 2024 Issuer DID to Registry

### DIFF
--- a/registry.json
+++ b/registry.json
@@ -81,6 +81,11 @@
       "name":"San José City College",
       "location":"San Jose, CA, USA",
       "url":"https://www.sjcc.edu"
+    },
+    "did:key:z6MkoowWdLogChc6mRp18YcKBd2yYTNnQLeHdiT73wjL1h6z": {
+      "name": "Trusted Learner Network (TLN) Unconference Issuer",
+      "location": "Tempe, AZ, USA",
+      "url": "https://tln.asu.edu/"
     }
   }
 }


### PR DESCRIPTION
As discussed with @dmitrizagidulin & @kimdhamilton -- for the Trusted Learner Network Issuance App to be able to issue a VC to the DCC/Pocket wallet (and, specifically, to allow the wallet to fully verify the credentials, which includes issuer validation against the DCC `issuer-registry`), the issuer DID needs to be registered within this trust registry.

For clarity, this is not intended as a permanent DID identity representation for the TLN, but rather an issuer specific to the 2024 Unconference event. I have named the issuer appropriately to convey that.